### PR TITLE
Report size exceeds the maximum GitHub comment size

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,13 @@ runs:
         path: outputs.zip
         if-no-files-found: ignore
 
+    - uses: actions/upload-artifact@v3
+      if: always() && steps.rcppdeepstate.outputs.truncated == 'true'
+      with:
+        name: Truncated comment
+        path: truncated.md
+        if-no-files-found: ignore
+
     - name: Comment on pull requests
       uses: actions/github-script@v6
       if: |

--- a/action.yml
+++ b/action.yml
@@ -58,6 +58,7 @@ runs:
       with:
         name: Test results
         path: outputs.zip
+        if-no-files-found: ignore
 
     - name: Comment on pull requests
       uses: actions/github-script@v6

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -12,6 +12,14 @@ GitHub_server_url <- Sys.getenv("GITHUB_SERVER_URL")
 GitHub_repository <- Sys.getenv("GITHUB_REPOSITORY")
 GitHub_head_ref <- Sys.getenv("GITHUB_HEAD_REF")
 
+# Here is the maximum GitHub's comment length. The original size is 65536,
+# however we consider that the remaining 536 characters are reserved for the
+# comment identifier(used to identify the comment when updating), the title
+# and for the message that will be printed if the message is truncated.
+max_comment_size <- 65000
+
+report_file <- file.path(GitHub_workspace, "report.md") 
+status <- 0 # default exit code status is 0 (success)
 
 package_root <- file.path(GitHub_workspace, location)
 description_file <- file.path(package_root, "DESCRIPTION")
@@ -27,15 +35,15 @@ package_name_line <- description_lines[grepl("^Package:", description_lines)]
 package_name <- gsub("Package: ", "", package_name_line[1])
 
 # analyze with RcppDeepState
-deepstate_harness_compile_run(package_root, seed=seed, verbose=verbose, 
+deepstate_harness_compile_run(package_root, seed=seed, verbose=verbose,
                               time.limit.seconds=time_limit)
-result <- deepstate_harness_analyze_pkg(package_root, max_inputs=max_inputs, 
+result <- deepstate_harness_analyze_pkg(package_root, max_inputs=max_inputs,
                                         verbose=verbose)
 
 
 # Auxiliary function used to get the errors positions for a single file that has
-# been analyzed. Each "logtableElement" correspond to a "data.table" instance 
-# where the second dimension describes the number of columns, whereas the second 
+# been analyzed. Each "logtableElement" correspond to a "data.table" instance
+# where the second dimension describes the number of columns, whereas the second
 # describes the number of errors found.
 getErrors <- function(logtableElement) {
   dim(logtableElement)[1]>0
@@ -60,7 +68,7 @@ getHyperlink <- function(analyzed_file) {
   gh_link <- paste0("[",file_ref,"](",final_hyperlink,")")
 }
 
-# this function generates a markdown version of an input list
+# Helper function that generates a markdown version of an input list
 getInputsMarkdown <- function(inputList) {
   markdown_res <- ""
   for (i in seq(length(inputList))) {
@@ -73,41 +81,71 @@ getInputsMarkdown <- function(inputList) {
   markdown_res
 }
 
-# helper function that generates the code for a test given the inputs
+# Helper function that generates the code for a test given the inputs
 getExecutableFile <- function(inputs, function_name) {
   inputList <- paste(capture.output(dput(inputs)), collapse="")
-  executable_file <- paste0("testlist <- ", inputList, "<br/>", 
-                            "result <- do.call(", package_name, "::", 
+  executable_file <- paste0("testlist <- ", inputList, "<br/>",
+                            "result <- do.call(", package_name, "::",
                             function_name, ", testlist)")
   markdown_res <- paste0("<details>", "<summary>", "Test code", "</summary>",
                          "<pre>", executable_file, "</pre>", "</details>")
 }
 
-# This function generates a markdown table given a data.table using less 
-# character as possible(avoiding unnecessary spacing)
-generateMarkdownTable <- function(table) {
+# This function generates a markdown table from given a data.table using less
+# character as possible(avoiding unnecessary spacing) and being withing the
+# character limit imposed by 'max_len'
+generateMarkdownTable <- function(table, max_len) {
+  truncated <- FALSE
+  truncated_msg <- paste("The table has been truncated because it exceeds the",
+                         "maximum allowed comment size. You can find the full",
+                         "markdown table in the artifact file associated to",
+                         "this workflow run.")
+
   header <- paste0("|", paste(colnames(table), collapse="|"), "|")
   line_sep <- paste(rep("|", length(colnames(table)) + 1), collapse="-")
-
   markdown_table <- paste(header, line_sep, sep="\n")
-  for (row_i in seq(nrow(table))){
+
+  remaining <- max_len - nchar(markdown_table)
+
+  for (row_i in seq(nrow(table))) {
     markdown_row <- paste0("|", paste(table[row_i], collapse="|"), "|")
-    markdown_table <- paste(markdown_table, markdown_row, sep="\n")
+    if (nchar(markdown_row) < remaining) {
+      markdown_table <- paste(markdown_table, markdown_row, sep="\n")
+      remaining <- remaining - nchar(markdown_row) 
+    }else {
+      truncated <- TRUE
+    }
+  }
+
+  if (truncated) {
+    markdown_table <- paste(markdown_table, truncated_msg, sep="\n\n")
+    output_truncated <- paste0("echo ::set-output name=truncated::true")
+    system(output_truncated, intern = FALSE)
   }
 
   markdown_table
 }
 
-report_file <- file.path(GitHub_workspace, "report.md")
-errors <- sapply(result$logtable,  getErrors)
-status <- 0
-
 rcppdeepstate_repo <- "https://github.com/FabrizioSandri/RcppDeepState"
-title <- paste0("## [RcppDeepState](", rcppdeepstate_repo, ") Report")
-write(title, report_file)
+write_to_report <- paste0("## [RcppDeepState](", rcppdeepstate_repo, ") Report")
 
+# Generate the summary table: contains for each function analyzed, the number of 
+# inputs tested
+analyzed_functions <- unlist(lapply(result$binaryfile, getFunctionName))
+analyzed_table <- cbind(data.table(func=analyzed_functions),result)
+colnames(analyzed_table)[1] <- "function_name"
+
+count_inputs <- analyzed_table[,.N, by=function_name]
+colnames(count_inputs)[2] <- "tested_inputs"
+
+summary_header <- "### Analyzed functions summary"
+summary_table <- generateMarkdownTable(count_inputs, max_comment_size)
+summary_table_md <- paste(summary_header, summary_table, sep="\n")
+
+max_comment_size <- max_comment_size - nchar(summary_table_md)
 
 # print all the errors and return a proper exit status code
+errors <- sapply(result$logtable,  getErrors)
 if (any(errors)) {
   print(result)
   print(result$logtable)
@@ -127,9 +165,9 @@ if (any(errors)) {
   first_error_table <- error_table[,.SD[1], by=func]
 
   # generate the report file
-  report_table <- data.table(function_name=c(), message=c(), file_line=c(), 
+  report_table <- data.table(function_name=c(), message=c(), file_line=c(),
                              address_trace=c(), R_code=c())
-                             
+  
   for (i in seq(dim(first_error_table)[1])) {
     
     file_line_link <- getHyperlink(first_error_table$logtable[[i]]$file.line[1])
@@ -139,17 +177,18 @@ if (any(errors)) {
     }
 
     message <- first_error_table$logtable[[i]]$message[1]
-    executable_file <- getExecutableFile(first_error_table$inputs[[i]], 
+    executable_file <- getExecutableFile(first_error_table$inputs[[i]],
                                          first_error_table$func[i])
 
     new_row <- data.table(function_name=first_error_table$func[i],
-                          message=message, file_line=file_line_link, 
-                          address_trace=address_trace_link, 
+                          message=message, file_line=file_line_link,
+                          address_trace=address_trace_link,
                           R_code=executable_file)
     report_table <- rbind(report_table, new_row)
   }
 
-  write(knitr::kable(report_table), report_file, append=TRUE)
+  report_table_md <- generateMarkdownTable(report_table, max_comment_size)
+  write_to_report <- paste(write_to_report, report_table_md, sep="\n")
 
   if (fail_ci_if_error == "true") {
     status <- 1
@@ -159,20 +198,11 @@ if (any(errors)) {
   system(output_errors, intern = FALSE)
 
   no_error_message <- "No error has been reported by RcppDeepState"
-  write(no_error_message, report_file, append=TRUE)
+  write_to_report <- paste(write_to_report, no_error_message, sep="\n")
 }
 
-# print the summary table: this table contains for each function analyzed, the 
-# number of inputs tested 
-analyzed_functions <- unlist(lapply(result$binaryfile, getFunctionName))
-analyzed_table <- cbind(data.table(func=analyzed_functions),result)
-colnames(analyzed_table)[1] <- "function_name"
+write_to_report <- paste(write_to_report, summary_table_md, sep="\n")
+write(write_to_report, report_file, append=FALSE)
 
-count_inputs <- analyzed_table[,.N, by=function_name]
-colnames(count_inputs)[2] <- "tested_inputs"
-
-summary_header <- "### Analyzed functions summary"
-write(summary_header, report_file, append=TRUE)
-write(knitr::kable(count_inputs), report_file, append=TRUE)
-
-quit(status=status)  # return an error code
+# return an error code
+quit(status=status)

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -109,6 +109,7 @@ generateMarkdownTable <- function(table, max_len) {
 
   for (row_i in seq(nrow(table))) {
     markdown_row <- paste0("|", paste(table[row_i], collapse="|"), "|")
+    markdown_row <- gsub("\n", "", markdown_row)
     if (nchar(markdown_row) < remaining) {
       markdown_table <- paste(markdown_table, markdown_row, sep="\n")
       remaining <- remaining - nchar(markdown_row) 

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -18,6 +18,7 @@ GitHub_head_ref <- Sys.getenv("GITHUB_HEAD_REF")
 # and for the message that will be printed if the message is truncated.
 max_comment_size <- 65000
 report_file <- file.path(GitHub_workspace, "report.md") 
+truncated_file <- file.path(GitHub_workspace, "truncated.md") 
 status <- 0 # default exit code status is 0 (success)
 
 package_root <- file.path(GitHub_workspace, location)
@@ -121,6 +122,9 @@ generateMarkdownTable <- function(table, max_len) {
     markdown_table <- paste(markdown_table, truncated_msg, sep="\n\n")
     output_truncated <- paste0("echo ::set-output name=truncated::true")
     system(output_truncated, intern = FALSE)
+
+    # save the full table
+    write(knitr::kable(table), truncated_file, append=TRUE)
   }
 
   markdown_table

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -85,7 +85,7 @@ getInputsMarkdown <- function(inputList) {
 getExecutableFile <- function(inputs, function_name) {
   inputList <- paste(capture.output(dput(inputs)), collapse="")
   executable_file <- paste0("testlist <- ", inputList, "<br/>",
-                            "result <- do.call(", package_name, "::",
+                            "result <- do.call(", package_name, ":::",
                             function_name, ", testlist)")
   markdown_res <- paste0("<details>", "<summary>", "Test code", "</summary>",
                          "<pre>", executable_file, "</pre>", "</details>")

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -17,14 +17,13 @@ GitHub_head_ref <- Sys.getenv("GITHUB_HEAD_REF")
 # comment identifier(used to identify the comment when updating), the title
 # and for the message that will be printed if the message is truncated.
 max_comment_size <- 65000
-
 report_file <- file.path(GitHub_workspace, "report.md") 
 status <- 0 # default exit code status is 0 (success)
 
 package_root <- file.path(GitHub_workspace, location)
 description_file <- file.path(package_root, "DESCRIPTION")
 if (!file.exists(description_file)) {
-  message(paste0("ERROR: ", location, " doesn't contain a valid package with a",
+  message(paste("ERROR:", location, "doesn't contain a valid package with a",
                  "DESCRIPTION file"))
   exit(1)
 }

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -83,6 +83,21 @@ getExecutableFile <- function(inputs, function_name) {
                          "<pre>", executable_file, "</pre>", "</details>")
 }
 
+# This function generates a markdown table given a data.table using less 
+# character as possible(avoiding unnecessary spacing)
+generateMarkdownTable <- function(table) {
+  header <- paste0("|", paste(colnames(table), collapse="|"), "|")
+  line_sep <- paste(rep("|", length(colnames(table)) + 1), collapse="-")
+
+  markdown_table <- paste(header, line_sep, sep="\n")
+  for (row_i in seq(nrow(table))){
+    markdown_row <- paste0("|", paste(table[row_i], collapse="|"), "|")
+    markdown_table <- paste(markdown_table, markdown_row, sep="\n")
+  }
+
+  markdown_table
+}
+
 report_file <- file.path(GitHub_workspace, "report.md")
 errors <- sapply(result$logtable,  getErrors)
 status <- 0


### PR DESCRIPTION
This pull request aims to solve the problem described in the issue #5: GitHub has a character restriction of 65536 per comment. 