### PR TITLE
Get errors count

### DIFF
--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -56,7 +56,7 @@ getErrors <- function(logtableElement) {
 # Auxiliary function used to get the number of inputs that generated errors for
 # a given batch of analysis results
 getErrorsCount <- function(batch){
-	sum(lapply(batch, nrow) > 0)
+	sum(unlist(lapply(batch, nrow)) > 0, na.rm = TRUE)
 }
 
 getFunctionName <- function(test_path) {

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -56,7 +56,7 @@ getErrors <- function(logtableElement) {
 # Auxiliary function used to get the number of inputs that generated errors for
 # a given batch of analysis results
 getErrorsCount <- function(batch){
-	sum(unlist(lapply(batch, nrow)) > 0, na.rm = TRUE)
+	sum(unlist(sapply(batch, nrow)) > 0, na.rm = TRUE)
 }
 
 getFunctionName <- function(test_path) {


### PR DESCRIPTION
This pull request aims to solve the problem that can happen in the `getErrorsCount` function that gave me a strange `Error: 'list' object cannot be coerced to type 'double'`