### PR TITLE
Parameters names/values

### DIFF
--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -26,7 +26,7 @@ jobs:
           location: /tests/testSAN
           fail_ci_if_error: false
           seed: 5
-          time_limit_seconds: 2
+          max_seconds_per_function: 2
           max_inputs: 3
           comment: true
           verbose: true

--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -24,6 +24,9 @@ jobs:
         uses: ./
         with:
           location: /tests/testSAN
-          fail_ci_if_error: 'false'
-          comment: 'true'
-          
+          fail_ci_if_error: false
+          seed: 5
+          time_limit: 2
+          max_inputs: 3
+          comment: true
+          verbose: true

--- a/.github/workflows/action-test.yaml
+++ b/.github/workflows/action-test.yaml
@@ -26,7 +26,7 @@ jobs:
           location: /tests/testSAN
           fail_ci_if_error: false
           seed: 5
-          time_limit: 2
+          time_limit_seconds: 2
           max_inputs: 3
           comment: true
           verbose: true

--- a/.github/workflows/no-error-package-test.yaml
+++ b/.github/workflows/no-error-package-test.yaml
@@ -18,5 +18,5 @@ jobs:
         uses: ./
         with:
           location: /tests/TestPackage
-          fail_ci_if_error: 'false'
-          comment: 'failure'
+          fail_ci_if_error: false
+          comment: failure

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RcppDeepState is a fuzz testing library made as a composition of three tools: Rc
 -   **fail_ci_if_error** (default value: `false`) - Specify if CI pipeline should fail when RcppDeepState finds errors;
 -   **location** (default value: `/`) - Relative path under `$GITHUB_WORKSPACE` that contains the package that needs to be analyzed. Default uses the `/` location relative to `$GITHUB_WORKSPACE`, that is `$GITHUB_WORKSPACE`;
 -   **seed** (default value: `-1`) - control the randomness of the inputs generated in the fuzzing phase;
--   **time_limit** (default value: `5`) - Fuzzing phase's duration in seconds;
+-   **time_limit_seconds** (default value: `5`) - Fuzzing phase's duration in seconds;
 -   **max_inputs** (default value: `3`) - Maximum number of inputs that will be processed by RcppDeepState;
 -   **comment** (default value: `false`) - Print the analysis results as a comment if run in a pull request. If set to `failure` only writes a comment if RcppDeepState discovers at least one issue;
 -   **verbose** (default value: `false`) - Enables verbose logging of RcppDeepState.
@@ -49,7 +49,7 @@ Before running this GitHub Action it's mandatory to run the [actions/checkout](h
 
     # This parameter controls the fuzzing phase's duration in seconds. 
     # Default: 5
-    time_limit: ''
+    time_limit_seconds: ''
 
     # Maximum number of inputs that will be processed by RcppDeepState. The 
     # fuzzing phase may generate a lot of inputs, however analyzing all of them

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Before running this GitHub Action it's mandatory to run the [actions/checkout](h
 
     # This parameter is used to specify if the CI pipeline should fail when 
     # RcppDeepState finds at least one error.
-    # Default: 'false'
+    # Default: false
     fail_ci_if_error: ''
 
     # Relative path under $GITHUB_WORKSPACE where the package that needs to be
@@ -63,13 +63,13 @@ Before running this GitHub Action it's mandatory to run the [actions/checkout](h
     # control whether the analysis result should be printed as a comment in the 
     # pull request. This parameter can be set to 'failure' to write comments
     # only if RcppDeepState discovers at least one issue.  
-    # Default: 'false'
+    # Default: false
     comment: ''
     
     # This parameter enables the verbose logging mode of RcppDeepState. If set 
     # to 'true' RcppDeepState will print more debugging information. If set to
     # 'false' only the analysis result will be printed on the standard output.
-    # Default: 'false'
+    # Default: false
     verbose: ''
 ```
 
@@ -95,7 +95,7 @@ jobs:
 
       - uses:  FabrizioSandri/RcppDeepState-action@main
         with:
-          comment: 'true'
+          comment: true
 ```
 
 #### Custom path example
@@ -121,8 +121,8 @@ jobs:
 
       - uses:  FabrizioSandri/RcppDeepState-action@main
         with:
-          location: '/inst/testpkgs/testSAN'
-          comment: 'true'
+          location: /inst/testpkgs/testSAN
+          comment: true
 ```
 
 #### CI fail example
@@ -150,6 +150,6 @@ jobs:
 
       - uses:  FabrizioSandri/RcppDeepState-action@main
         with:
-          fail_ci_if_error: 'true'
-          comment: 'true'
+          fail_ci_if_error: true
+          comment: true
 ```

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ RcppDeepState is a fuzz testing library made as a composition of three tools: Rc
 -   **fail_ci_if_error** (default value: `false`) - Specify if CI pipeline should fail when RcppDeepState finds errors;
 -   **location** (default value: `/`) - Relative path under `$GITHUB_WORKSPACE` that contains the package that needs to be analyzed. Default uses the `/` location relative to `$GITHUB_WORKSPACE`, that is `$GITHUB_WORKSPACE`;
 -   **seed** (default value: `-1`) - control the randomness of the inputs generated in the fuzzing phase;
--   **time_limit_seconds** (default value: `5`) - Fuzzing phase's duration in seconds;
+-   **max_seconds_per_function** (default value: `5`) - Fuzzing phase's duration in seconds for every function;
 -   **max_inputs** (default value: `3`) - Maximum number of inputs that will be processed by RcppDeepState;
 -   **comment** (default value: `false`) - Print the analysis results as a comment if run in a pull request. If set to `failure` only writes a comment if RcppDeepState discovers at least one issue;
 -   **verbose** (default value: `false`) - Enables verbose logging of RcppDeepState.
@@ -49,7 +49,7 @@ Before running this GitHub Action it's mandatory to run the [actions/checkout](h
 
     # This parameter controls the fuzzing phase's duration in seconds. 
     # Default: 5
-    time_limit_seconds: ''
+    max_seconds_per_function: ''
 
     # Maximum number of inputs that will be processed by RcppDeepState. The 
     # fuzzing phase may generate a lot of inputs, however analyzing all of them

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Seed used for deterministic fuzz testing and reproduce the analysis results'
     required: false
     default: '-1'
-  time_limit_seconds:
+  max_seconds_per_function:
     description: "Fuzzing phase's duration in seconds"
     required: false
     default: '2'
@@ -49,7 +49,7 @@ runs:
         fail_ci_if_error: ${{ inputs.fail_ci_if_error }}
         location: ${{ inputs.location }}
         seed: ${{ inputs.seed }}
-        time_limit_seconds: ${{ inputs.time_limit_seconds }}
+        max_seconds_per_function: ${{ inputs.max_seconds_per_function }}
         max_inputs: ${{ inputs.max_inputs }}
         verbose: ${{ inputs.verbose }}
 

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Seed used for deterministic fuzz testing and reproduce the analysis results'
     required: false
     default: '-1'
-  time_limit:
+  time_limit_seconds:
     description: "Fuzzing phase's duration in seconds"
     required: false
     default: '2'
@@ -49,7 +49,7 @@ runs:
         fail_ci_if_error: ${{ inputs.fail_ci_if_error }}
         location: ${{ inputs.location }}
         seed: ${{ inputs.seed }}
-        time_limit: ${{ inputs.time_limit }}
+        time_limit_seconds: ${{ inputs.time_limit_seconds }}
         max_inputs: ${{ inputs.max_inputs }}
         verbose: ${{ inputs.verbose }}
 

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Seed used for deterministic fuzz testing and reproduce the analysis results'
     required: false
     default: '-1'
-  time_limit_seconds:
+  max_seconds_per_function:
     description: "Fuzzing phase's duration in seconds"
     required: false
     default: '2'
@@ -34,6 +34,6 @@ runs:
     - ${{ inputs.fail_ci_if_error }}
     - ${{ inputs.location }}
     - ${{ inputs.seed }}
-    - ${{ inputs.time_limit_seconds }}
+    - ${{ inputs.max_seconds_per_function }}
     - ${{ inputs.max_inputs }}
     - ${{ inputs.verbose }}

--- a/docker/action.yml
+++ b/docker/action.yml
@@ -14,7 +14,7 @@ inputs:
     description: 'Seed used for deterministic fuzz testing and reproduce the analysis results'
     required: false
     default: '-1'
-  time_limit:
+  time_limit_seconds:
     description: "Fuzzing phase's duration in seconds"
     required: false
     default: '2'
@@ -34,6 +34,6 @@ runs:
     - ${{ inputs.fail_ci_if_error }}
     - ${{ inputs.location }}
     - ${{ inputs.seed }}
-    - ${{ inputs.time_limit }}
+    - ${{ inputs.time_limit_seconds }}
     - ${{ inputs.max_inputs }}
     - ${{ inputs.verbose }}

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -50,13 +50,13 @@ result <- deepstate_harness_analyze_pkg(package_root, max_inputs=max_inputs,
 # where the second dimension describes the number of columns, whereas the second
 # describes the number of errors found.
 getErrors <- function(logtableElement) {
-  dim(logtableElement)[1]>0
+  if (!is.data.table(logtableElement)) FALSE else dim(logtableElement)[1]>0
 }
 
 # Auxiliary function used to get the number of inputs that generated errors for
 # a given batch of analysis results
 getErrorsCount <- function(batch){
-	sum(unlist(sapply(batch, nrow)) > 0, na.rm = TRUE)
+  sum(unlist(sapply(batch, nrow)) > 0, na.rm = TRUE)
 }
 
 getFunctionName <- function(test_path) {

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -184,11 +184,9 @@ if (any(errors)) {
     file_line <- first_error_table$logtable[[i]]$file.line[1]
     file_line_link <- if (is.na(file_line)) "-" else getHyperlink(file_line)
     
-    address_trace_link <- first_error_table$logtable[[i]]$address.trace[1]
-    if (is.na(address_trace_link)){
-      address_trace_link <- "No Address Trace found"
-    }
-    
+    address_trace <- first_error_table$logtable[[i]]$address.trace[1]
+    address_trace_link <- if (is.na(address_trace)) "No Address Trace found" 
+                          else address_trace    
     if (address_trace_link != "No Address Trace found") {
       address_trace_link <- getHyperlink(address_trace_link)
     }

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -181,8 +181,9 @@ if (any(errors)) {
                              address_trace=c(), R_code=c())
   
   for (i in seq(dim(first_error_table)[1])) {
+    file_line <- first_error_table$logtable[[i]]$file.line[1]
+    file_line_link <- if (is.na(file_line)) "-" else getHyperlink(file_line)
     
-    file_line_link <- getHyperlink(first_error_table$logtable[[i]]$file.line[1])
     address_trace_link <- first_error_table$logtable[[i]]$address.trace[1]
     if (is.na(address_trace_link)){
       address_trace_link <- "No Address Trace found"

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -4,7 +4,7 @@ require(data.table)
 GitHub_workspace <- Sys.getenv("GITHUB_WORKSPACE")
 location <- Sys.getenv("INPUT_LOCATION")
 seed_input <- Sys.getenv("INPUT_SEED")
-time_limit <- Sys.getenv("INPUT_TIME_LIMIT")
+time_limit_seconds <- Sys.getenv("INPUT_TIME_LIMIT_SECONDS")
 max_inputs <- Sys.getenv("INPUT_MAX_INPUTS")
 verbose <- if (Sys.getenv("INPUT_VERBOSE") == "true") TRUE else FALSE
 fail_ci_if_error <- Sys.getenv("INPUT_FAIL_CI_IF_ERROR")
@@ -40,7 +40,7 @@ package_name <- gsub("Package: ", "", package_name_line[1])
 
 # analyze with RcppDeepState
 deepstate_harness_compile_run(package_root, seed=seed, verbose=verbose,
-                              time.limit.seconds=time_limit)
+                              time.limit.seconds=time_limit_seconds)
 result <- deepstate_harness_analyze_pkg(package_root, max_inputs=max_inputs,
                                         verbose=verbose)
 

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -4,7 +4,7 @@ require(data.table)
 GitHub_workspace <- Sys.getenv("GITHUB_WORKSPACE")
 location <- Sys.getenv("INPUT_LOCATION")
 seed_input <- Sys.getenv("INPUT_SEED")
-time_limit_seconds <- Sys.getenv("INPUT_TIME_LIMIT_SECONDS")
+max_seconds_per_function <- Sys.getenv("INPUT_MAX_SECONDS_PER_FUNCTION")
 max_inputs <- Sys.getenv("INPUT_MAX_INPUTS")
 verbose <- if (Sys.getenv("INPUT_VERBOSE") == "true") TRUE else FALSE
 fail_ci_if_error <- Sys.getenv("INPUT_FAIL_CI_IF_ERROR")
@@ -40,7 +40,7 @@ package_name <- gsub("Package: ", "", package_name_line[1])
 
 # analyze with RcppDeepState
 deepstate_harness_compile_run(package_root, seed=seed, verbose=verbose,
-                              time.limit.seconds=time_limit_seconds)
+                              time.limit.seconds=max_seconds_per_function)
 result <- deepstate_harness_analyze_pkg(package_root, max_inputs=max_inputs,
                                         verbose=verbose)
 

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -67,7 +67,7 @@ getFunctionName <- function(test_path) {
 # helper function that returns the Github link (in markdown format) for a given
 # input file.
 getHyperlink <- function(analyzed_file) {
-  file_ref <- gsub(" ", "", analyzed_file)
+  file_ref <- basename(gsub(" ", "", analyzed_file))
   refs <- unlist(strsplit(file_ref, ":"))
 
   file_hyperlink <- paste(GitHub_repository, "blob", pull_sha, location, "src", 

--- a/docker/src/analyze_package.R
+++ b/docker/src/analyze_package.R
@@ -184,6 +184,10 @@ if (any(errors)) {
     
     file_line_link <- getHyperlink(first_error_table$logtable[[i]]$file.line[1])
     address_trace_link <- first_error_table$logtable[[i]]$address.trace[1]
+    if (is.na(address_trace_link)){
+      address_trace_link <- "No Address Trace found"
+    }
+    
     if (address_trace_link != "No Address Trace found") {
       address_trace_link <- getHyperlink(address_trace_link)
     }

--- a/docker/src/entrypoint.sh
+++ b/docker/src/entrypoint.sh
@@ -13,10 +13,10 @@ retVal=$?
 echo "RcppDeepState analysis completed"
 
 # remove vgcore files and adjust permissions
-find "$GITHUB_WORKSPACE/$INPUT_LOCATION/inst/testfiles" -maxdepth 2 -name 'vgcore*' | xargs rm
+find "$GITHUB_WORKSPACE/$INPUT_LOCATION/inst/testfiles" -maxdepth 2 -name 'vgcore*' | xargs -r rm
 
-find "$GITHUB_WORKSPACE/$INPUT_LOCATION/inst/testfiles" -type d | xargs chmod 755;
-find "$GITHUB_WORKSPACE/$INPUT_LOCATION/inst/testfiles" -type f | xargs chmod 644;
+find "$GITHUB_WORKSPACE/$INPUT_LOCATION/inst/testfiles" -type d | xargs -r chmod 755;
+find "$GITHUB_WORKSPACE/$INPUT_LOCATION/inst/testfiles" -type f | xargs -r chmod 644;
 
 # return the exit status to the action
 exit $retVal


### PR DESCRIPTION
The changes made in this pull request amount to:
* change the name of the `time_limit` parameter to `max_seconds_per_function`;
* check whether single quotes are required for parameters like booleans and integers inside workflow files;
* solve the problem that cause the action's log to include a warning message: `rm: missing operand`;
* solve the issue that cause a duplicate concatenation of the `src` path in the hyperlinks of the comment;
* strengthened the tests on NA values to avoid unexpected errors.

Fixes #16 